### PR TITLE
gst-libav: Fix json format and remove non-exist config-opts

### DIFF
--- a/public/modules.json
+++ b/public/modules.json
@@ -245,7 +245,6 @@
         "module": {
           "name": "gst-libav",
           "buildsystem": "meson",
-          "config-opts": "--with-system-libav=no",
           "sources": [
             {
               "type": "archive",
@@ -261,7 +260,9 @@
         "module": {
           "name": "gst-libav",
           "buildsystem": "autotools",
-          "config-opts": "--with-system-libav=no",
+          "config-opts": [
+            "--with-system-libav=no"
+          ],
           "sources": [
             {
               "type": "archive",


### PR DESCRIPTION
- Fix json format (`config-opts` take an array)
- Remove the config-opts that does not exist on 1.19.1 (1.16 has but it seems to be removed at some point)
